### PR TITLE
SNO-441-object-history

### DIFF
--- a/src/snovault/resource_views.py
+++ b/src/snovault/resource_views.py
@@ -369,7 +369,7 @@ def item_view_raw(context, request):
 @view_config(context=Item, permission='view', request_method='GET', name='history')
 def item_view_history(context, request):
     props = context.model.data[''].history
-    
+
     history = []
     for p in props:
         history.append(

--- a/src/snovault/resource_views.py
+++ b/src/snovault/resource_views.py
@@ -372,17 +372,17 @@ def item_view_history(context, request):
     history = []
     for p in props:
         history.append({
-            "timestamp": p.transaction.timestamp.isoformat(),
-            "userid": p.transaction.data["userid"],
-            "props": p.properties
+            'timestamp': p.transaction.timestamp.isoformat(),
+            'userid': p.transaction.data['userid'],
+            'props': p.properties
         })
-    history = sorted(history, key=lambda t: t["timestamp"])
+    history = sorted(history, key=lambda t: t['timestamp'])
     latest = history[-1]
 
     return {
-        "rid": request.resource_path(context),
-        "latest": latest,
-        "history": history
+        'rid': request.resource_path(context),
+        'latest': latest,
+        'history': history
     }
 
 

--- a/src/snovault/resource_views.py
+++ b/src/snovault/resource_views.py
@@ -376,7 +376,7 @@ def item_view_history(context, request):
             "userid": p.transaction.data["userid"],
             "props": p.properties
         })
-    history = sorted(history, key="timestamp")
+    history = sorted(history, key=lambda t: t["timestamp"])
     latest = history[0]
 
     return {

--- a/src/snovault/resource_views.py
+++ b/src/snovault/resource_views.py
@@ -358,14 +358,14 @@ def item_view_columns(context, request):
     return subset
 
 
-@view_config(context=Item, permission='view', request_method='GET',
+@view_config(context=Item, permission='view_raw', request_method='GET',
              name='raw')
 def item_view_raw(context, request):
     if asbool(request.params.get('upgrade', True)):
         return context.upgrade_properties()
     return context.properties
 
-@view_config(context=Item, permission='view', request_method='GET', name='history')
+@view_config(context=Item, permission='view_raw', request_method='GET', name='history')
 def item_view_history(context, request):
     db = request.registry[DBSESSION]
     props = db.query(storage.PropertySheet).filter(storage.PropertySheet.rid == context.uuid).all()

--- a/src/snovault/resource_views.py
+++ b/src/snovault/resource_views.py
@@ -366,10 +366,10 @@ def item_view_raw(context, request):
     return context.properties
 
 
-@view_config(context=Item, permission='view_raw', request_method='GET', name='history')
+@view_config(context=Item, permission='view', request_method='GET', name='history')
 def item_view_history(context, request):
-    # db = request.registry[DBSESSION]
-    props = context.data.history
+    props = context.model.data[''].history
+    
     history = []
     for p in props:
         history.append(

--- a/src/snovault/resource_views.py
+++ b/src/snovault/resource_views.py
@@ -365,6 +365,7 @@ def item_view_raw(context, request):
         return context.upgrade_properties()
     return context.properties
 
+
 @view_config(context=Item, permission='view_raw', request_method='GET', name='history')
 def item_view_history(context, request):
     db = request.registry[DBSESSION]

--- a/src/snovault/resource_views.py
+++ b/src/snovault/resource_views.py
@@ -368,15 +368,17 @@ def item_view_raw(context, request):
 
 @view_config(context=Item, permission='view_raw', request_method='GET', name='history')
 def item_view_history(context, request):
-    db = request.registry[DBSESSION]
-    props = db.query(storage.PropertySheet).filter(storage.PropertySheet.rid == context.uuid).all()
+    # db = request.registry[DBSESSION]
+    props = context.data.history
     history = []
     for p in props:
-        history.append({
-            'timestamp': p.transaction.timestamp.isoformat(),
-            'userid': p.transaction.data['userid'],
-            'props': p.properties
-        })
+        history.append(
+            {
+                'timestamp': p.transaction.timestamp.isoformat(),
+                'userid': p.transaction.data['userid'],
+                'props': p.properties
+            }
+        )
     history = sorted(history, key=lambda t: t['timestamp'])
     latest = history[-1]
 

--- a/src/snovault/resource_views.py
+++ b/src/snovault/resource_views.py
@@ -377,7 +377,7 @@ def item_view_history(context, request):
             "props": p.properties
         })
     history = sorted(history, key=lambda t: t["timestamp"])
-    latest = history[0]
+    latest = history[-1]
 
     return {
         "rid": request.resource_path(context),

--- a/src/snovault/resource_views.py
+++ b/src/snovault/resource_views.py
@@ -376,9 +376,12 @@ def item_view_history(context, request):
             "userid": p.transaction.data["userid"],
             "props": p.properties
         })
+    history = sorted(history, key="timestamp")
+    latest = history[0]
 
     return {
         "rid": request.resource_path(context),
+        "latest": latest,
         "history": history
     }
 

--- a/src/snowflakes/tests/test_views.py
+++ b/src/snowflakes/tests/test_views.py
@@ -152,12 +152,14 @@ def test_views_object_with_select_calculated_properties(workbook, testapp):
     assert 'another_test_calculated' not in r.json
     assert 'conditional_test_calculated' in r.json
 
+
 def test_view_history_view(workbook, testapp):
     r = testapp.get('/snowballs/SNOSS000AEN/?frame=history')
     assert 'latest' in r.json
-    assert r.json['rid'] == "/snowballs/SNOSS000AEN/"
+    assert r.json['rid'] == '/snowballs/SNOSS000AEN/'
     assert 'history' in r.json
     assert len(r.json['history']) == 1
+
 
 @pytest.mark.slow
 @pytest.mark.parametrize(('item_type', 'length'), TYPE_LENGTH.items())

--- a/src/snowflakes/tests/test_views.py
+++ b/src/snowflakes/tests/test_views.py
@@ -152,6 +152,12 @@ def test_views_object_with_select_calculated_properties(workbook, testapp):
     assert 'another_test_calculated' not in r.json
     assert 'conditional_test_calculated' in r.json
 
+def test_view_history_view(workbook, testapp):
+    r = testapp.get('/snowballs/SNOSS000AEN/?frame=history')
+    assert 'latest' in r.json
+    assert r.json['rid'] == "/snowballs/SNOSS000AEN/"
+    assert 'history' in r.json
+    assert len(r.json['history']) == 1
 
 @pytest.mark.slow
 @pytest.mark.parametrize(('item_type', 'length'), TYPE_LENGTH.items())


### PR DESCRIPTION
Currently this adds a new `frame` called `history` which grabs the all versions of an object and the timestamp of the update. I'm not sure if using frame is the best way to do this, and I'm very open to feedback and help in actually placing this route. This is my first time in snovault and I want what I'm doing to fit in well. 