### PR TITLE
SNO-42-add-object-history-view

### DIFF
--- a/src/snovault/elasticsearch/__init__.py
+++ b/src/snovault/elasticsearch/__init__.py
@@ -49,7 +49,7 @@ def datastore(request):
     if request.__parent__ is not None:
         return request.__parent__.datastore
     datastore = 'database'
-    if request.params.get('frame') in ['edit', 'history']:
+    if request.params.get('frame') == 'edit':
         return datastore
     if request.method in ('HEAD', 'GET'):
         datastore = request.params.get('datastore') or \

--- a/src/snovault/elasticsearch/__init__.py
+++ b/src/snovault/elasticsearch/__init__.py
@@ -49,7 +49,7 @@ def datastore(request):
     if request.__parent__ is not None:
         return request.__parent__.datastore
     datastore = 'database'
-    if request.params.get('frame') == 'edit':
+    if request.params.get('frame') == 'edit' or request.params.get('frame') == 'history':
         return datastore
     if request.method in ('HEAD', 'GET'):
         datastore = request.params.get('datastore') or \

--- a/src/snovault/elasticsearch/__init__.py
+++ b/src/snovault/elasticsearch/__init__.py
@@ -49,7 +49,7 @@ def datastore(request):
     if request.__parent__ is not None:
         return request.__parent__.datastore
     datastore = 'database'
-    if request.params.get('frame') == 'edit' or request.params.get('frame') == 'history':
+    if request.params.get('frame') in ['edit', 'history']:
         return datastore
     if request.method in ('HEAD', 'GET'):
         datastore = request.params.get('datastore') or \

--- a/src/snovault/resource_views.py
+++ b/src/snovault/resource_views.py
@@ -23,14 +23,12 @@ from snosearch.fields import NotificationResponseField
 from snosearch.parsers import ParamsParser
 from snosearch.parsers import QueryString
 from snosearch.responses import FieldedResponse
-from snovault import storage
-from sqlalchemy import select
 from .calculated import calculate_properties
 from .calculated import calculate_select_properties
 from .calculated import calculate_filtered_properties
 from .calculated import _should_render_property
 from .etag import etag_tid
-from .interfaces import CONNECTION, DBSESSION
+from .interfaces import CONNECTION
 from .elasticsearch.interfaces import ELASTIC_SEARCH
 from .resources import (
     AbstractCollection,

--- a/src/snovault/resource_views.py
+++ b/src/snovault/resource_views.py
@@ -369,7 +369,7 @@ def item_view_raw(context, request):
 @view_config(context=Item, permission='view', request_method='GET', name='history')
 def item_view_history(context, request):
     props = context.model.data[''].history
-    
+
     history = []
     for p in props:
         history.append(

--- a/src/snovault/resource_views.py
+++ b/src/snovault/resource_views.py
@@ -372,17 +372,17 @@ def item_view_history(context, request):
     history = []
     for p in props:
         history.append({
-            "timestamp": p.transaction.timestamp.isoformat(),
-            "userid": p.transaction.data["userid"],
-            "props": p.properties
+            'timestamp': p.transaction.timestamp.isoformat(),
+            'userid': p.transaction.data['userid'],
+            'props': p.properties
         })
-    history = sorted(history, key=lambda t: t["timestamp"])
+    history = sorted(history, key=lambda t: t['timestamp'])
     latest = history[-1]
 
     return {
-        "rid": request.resource_path(context),
-        "latest": latest,
-        "history": history
+        'rid': request.resource_path(context),
+        'latest': latest,
+        'history': history
     }
 
 

--- a/src/snovault/resource_views.py
+++ b/src/snovault/resource_views.py
@@ -30,7 +30,7 @@ from .calculated import _should_render_property
 from .etag import etag_tid
 from snovault import storage
 from sqlalchemy import select
-from .interfaces import CONNECTION, DBSESSION
+from .interfaces import CONNECTION, DBSESSION, STORAGE
 from .elasticsearch.interfaces import ELASTIC_SEARCH
 from .resources import (
     AbstractCollection,
@@ -368,8 +368,12 @@ def item_view_raw(context, request):
 
 @view_config(context=Item, permission='view_raw', request_method='GET', name='history')
 def item_view_history(context, request):
-    db = request.registry[DBSESSION]
-    props = db.query(storage.PropertySheet).filter(storage.PropertySheet.rid == context.uuid).all()
+    model = context.model
+    if request.datastore != 'datastore':
+        # Get model from database
+        model = request.registry[STORAGE].write.get_by_uuid(str(context.uuid))
+
+    props = model.data[''].history
 
     history = []
     for p in props:

--- a/src/snovault/resource_views.py
+++ b/src/snovault/resource_views.py
@@ -376,7 +376,7 @@ def item_view_history(context, request):
             "userid": p.transaction.data["userid"],
             "props": p.properties
         })
-    history = sorted(history, key="timestamp")
+    history = sorted(history, key=lambda t: t["timestamp"])
     latest = history[0]
 
     return {

--- a/src/snovault/resource_views.py
+++ b/src/snovault/resource_views.py
@@ -28,9 +28,7 @@ from .calculated import calculate_select_properties
 from .calculated import calculate_filtered_properties
 from .calculated import _should_render_property
 from .etag import etag_tid
-from snovault import storage
-from sqlalchemy import select
-from .interfaces import CONNECTION, DBSESSION, STORAGE
+from .interfaces import CONNECTION, STORAGE
 from .elasticsearch.interfaces import ELASTIC_SEARCH
 from .resources import (
     AbstractCollection,

--- a/src/snovault/resource_views.py
+++ b/src/snovault/resource_views.py
@@ -23,6 +23,7 @@ from snosearch.fields import NotificationResponseField
 from snosearch.parsers import ParamsParser
 from snosearch.parsers import QueryString
 from snosearch.responses import FieldedResponse
+from snovault.storage import Resource
 from .calculated import calculate_properties
 from .calculated import calculate_select_properties
 from .calculated import calculate_filtered_properties
@@ -367,8 +368,8 @@ def item_view_raw(context, request):
 @view_config(context=Item, permission='view_raw', request_method='GET', name='history')
 def item_view_history(context, request):
     model = context.model
-    if request.datastore != 'datastore':
-        # Get model from database
+    if not isinstance(model, Resource):
+        # Get model from database if it's not a storage Resource
         model = request.registry[STORAGE].write.get_by_uuid(str(context.uuid))
 
     props = model.data[''].history

--- a/src/snovault/resource_views.py
+++ b/src/snovault/resource_views.py
@@ -358,14 +358,14 @@ def item_view_columns(context, request):
     return subset
 
 
-@view_config(context=Item, permission='view', request_method='GET',
+@view_config(context=Item, permission='view_raw', request_method='GET',
              name='raw')
 def item_view_raw(context, request):
     if asbool(request.params.get('upgrade', True)):
         return context.upgrade_properties()
     return context.properties
 
-@view_config(context=Item, permission='view', request_method='GET', name='history')
+@view_config(context=Item, permission='view_raw', request_method='GET', name='history')
 def item_view_history(context, request):
     db = request.registry[DBSESSION]
     props = db.query(storage.PropertySheet).filter(storage.PropertySheet.rid == context.uuid).all()

--- a/src/snovault/resource_views.py
+++ b/src/snovault/resource_views.py
@@ -28,7 +28,9 @@ from .calculated import calculate_select_properties
 from .calculated import calculate_filtered_properties
 from .calculated import _should_render_property
 from .etag import etag_tid
-from .interfaces import CONNECTION
+from snovault import storage
+from sqlalchemy import select
+from .interfaces import CONNECTION, DBSESSION
 from .elasticsearch.interfaces import ELASTIC_SEARCH
 from .resources import (
     AbstractCollection,
@@ -366,7 +368,8 @@ def item_view_raw(context, request):
 
 @view_config(context=Item, permission='view_raw', request_method='GET', name='history')
 def item_view_history(context, request):
-    props = context.model.data[''].history
+    db = request.registry[DBSESSION]
+    props = db.query(storage.PropertySheet).filter(storage.PropertySheet.rid == context.uuid).all()
 
     history = []
     for p in props:

--- a/src/snovault/resource_views.py
+++ b/src/snovault/resource_views.py
@@ -366,10 +366,10 @@ def item_view_raw(context, request):
     return context.properties
 
 
-@view_config(context=Item, permission='view_raw', request_method='GET', name='history')
+@view_config(context=Item, permission='view', request_method='GET', name='history')
 def item_view_history(context, request):
-    # db = request.registry[DBSESSION]
-    props = context.data.history
+    props = context.model.data[''].history
+    
     history = []
     for p in props:
         history.append(

--- a/src/snovault/resource_views.py
+++ b/src/snovault/resource_views.py
@@ -365,6 +365,7 @@ def item_view_raw(context, request):
         return context.upgrade_properties()
     return context.properties
 
+
 @view_config(context=Item, permission='view_raw', request_method='GET', name='history')
 def item_view_history(context, request):
     db = request.registry[DBSESSION]

--- a/src/snovault/resource_views.py
+++ b/src/snovault/resource_views.py
@@ -366,7 +366,7 @@ def item_view_raw(context, request):
     return context.properties
 
 
-@view_config(context=Item, permission='view', request_method='GET', name='history')
+@view_config(context=Item, permission='view_raw', request_method='GET', name='history')
 def item_view_history(context, request):
     props = context.model.data[''].history
 

--- a/src/snovault/resource_views.py
+++ b/src/snovault/resource_views.py
@@ -368,15 +368,17 @@ def item_view_raw(context, request):
 
 @view_config(context=Item, permission='view_raw', request_method='GET', name='history')
 def item_view_history(context, request):
-    db = request.registry[DBSESSION]
-    props = db.query(storage.PropertySheet).filter(storage.PropertySheet.rid == context.uuid).all()
+    # db = request.registry[DBSESSION]
+    props = context.data.history
     history = []
     for p in props:
-        history.append({
-            'timestamp': p.transaction.timestamp.isoformat(),
-            'userid': p.transaction.data['userid'],
-            'props': p.properties
-        })
+        history.append(
+            {
+                'timestamp': p.transaction.timestamp.isoformat(),
+                'userid': p.transaction.data['userid'],
+                'props': p.properties
+            }
+        )
     history = sorted(history, key=lambda t: t['timestamp'])
     latest = history[-1]
 

--- a/src/snovault/resource_views.py
+++ b/src/snovault/resource_views.py
@@ -377,7 +377,7 @@ def item_view_history(context, request):
             "props": p.properties
         })
     history = sorted(history, key=lambda t: t["timestamp"])
-    latest = history[0]
+    latest = history[-1]
 
     return {
         "rid": request.resource_path(context),

--- a/src/snovault/resource_views.py
+++ b/src/snovault/resource_views.py
@@ -376,9 +376,12 @@ def item_view_history(context, request):
             "userid": p.transaction.data["userid"],
             "props": p.properties
         })
+    history = sorted(history, key="timestamp")
+    latest = history[0]
 
     return {
         "rid": request.resource_path(context),
+        "latest": latest,
         "history": history
     }
 

--- a/src/snowflakes/tests/test_views.py
+++ b/src/snowflakes/tests/test_views.py
@@ -152,12 +152,14 @@ def test_views_object_with_select_calculated_properties(workbook, testapp):
     assert 'another_test_calculated' not in r.json
     assert 'conditional_test_calculated' in r.json
 
+
 def test_view_history_view(workbook, testapp):
     r = testapp.get('/snowballs/SNOSS000AEN/?frame=history')
     assert 'latest' in r.json
-    assert r.json['rid'] == "/snowballs/SNOSS000AEN/"
+    assert r.json['rid'] == '/snowballs/SNOSS000AEN/'
     assert 'history' in r.json
     assert len(r.json['history']) == 1
+
 
 @pytest.mark.slow
 @pytest.mark.parametrize(('item_type', 'length'), TYPE_LENGTH.items())

--- a/src/snowflakes/tests/test_views.py
+++ b/src/snowflakes/tests/test_views.py
@@ -152,6 +152,12 @@ def test_views_object_with_select_calculated_properties(workbook, testapp):
     assert 'another_test_calculated' not in r.json
     assert 'conditional_test_calculated' in r.json
 
+def test_view_history_view(workbook, testapp):
+    r = testapp.get('/snowballs/SNOSS000AEN/?frame=history')
+    assert 'latest' in r.json
+    assert r.json['rid'] == "/snowballs/SNOSS000AEN/"
+    assert 'history' in r.json
+    assert len(r.json['history']) == 1
 
 @pytest.mark.slow
 @pytest.mark.parametrize(('item_type', 'length'), TYPE_LENGTH.items())


### PR DESCRIPTION
Currently this adds a new `frame` called `history` which grabs the all versions of an object and the timestamp of the update. I'm not sure if using frame is the best way to do this, and I'm very open to feedback and help in actually placing this route. This is my first time in snovault and I want what I'm doing to fit in well. 